### PR TITLE
Add "scope" as an acceptable key to prevent IssueType throwing exception

### DIFF
--- a/src/Jira/IssueType.php
+++ b/src/Jira/IssueType.php
@@ -90,6 +90,7 @@ class IssueType
 		'name',
 		'subtask',
 		'avatarId',
+		'scope',
 	);
 
 	/**


### PR DESCRIPTION
Some time ago JIRA API was changed and now `scope` is returned as part of `issuetype` properties in the list of returned issues (see https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-api-2-issueLink-linkId-get).

Since it's not explicitly whitelisted in `\chobie\Jira\ IssueType::$_acceptableKeys` property the exception is thrown during API response parsing.